### PR TITLE
fix: 修改demo-ervice-cache装饰器的传参为5000，与注释5秒一致

### DIFF
--- a/src/modules/demo/service/cache.ts
+++ b/src/modules/demo/service/cache.ts
@@ -7,7 +7,7 @@ import { CoolCache } from '@cool-midway/core';
 @Provide()
 export class DemoCacheService {
   // 数据缓存5秒
-  @CoolCache(5)
+  @CoolCache(5000)
   async get() {
     console.log('执行方法');
     return {


### PR DESCRIPTION
### 问题描述
当前代码中的 `CoolCache` 装饰器参数设置为 `5` 毫秒，但注释说明数据缓存时间应为 `5` 秒。为了确保缓存时间符合预期，需要将参数修改为 `5000` 毫秒。

### 解决方案
- 将 `CoolCache` 装饰器的参数从 `5` 修改为 `5000` 毫秒，以确保数据缓存时间为 `5` 秒。

### 测试
- 已在本地环境中测试，确保缓存时间确实为 `5` 秒。
- 确认修改后功能正常，未引入新的问题。
