### PR TITLE
fix: 修复生产环境后端国际化不生效的问题

### DIFF
--- a/src/modules/base/service/translate.ts
+++ b/src/modules/base/service/translate.ts
@@ -84,7 +84,7 @@ export class BaseTranslateService {
       return;
     }
     if (!this.basePath) {
-      this.basePath = path.join(this.app.getBaseDir(), '..', 'src', 'locales');
+      this.basePath = path.join(this.app.getBaseDir(), '..', this.app.getEnv() === 'local' ? 'src' : 'dist', 'locales');
     }
 
     // 清空现有映射


### PR DESCRIPTION
生产环境部署排除src包，但仍然读取了src中的内容